### PR TITLE
Make the dogfood host build from a clean checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,9 @@ jobs:
         run: |
           dotnet msbuild tests/dotnet/Vidra.CodeGen.AppFixture/Vidra.CodeGen.AppFixture.csproj -p:Configuration=Release -t:VidraCodeGenCheck
           dotnet msbuild tests/dotnet/Vidra.CodeGen.AppFixture/MissingAggregateTarget.proj -t:VidraCodeGen
+          # Multi-assembly, core-scope codegen — the shape the dogfood host uses,
+          # exercised here so it isn't only covered by the two platform jobs.
+          dotnet msbuild tests/dotnet/Vidra.CodeGen.AppFixture/AggregateScope.proj -t:VerifyAggregateCodeGen
 
       - name: Run Vidra.Modules.FileSystem.Tests
         run: dotnet test tests/dotnet/Vidra.Modules.FileSystem.Tests/Vidra.Modules.FileSystem.Tests.csproj -c Release --no-build --logger "trx;LogFileName=modules-filesystem.trx"
@@ -331,14 +334,23 @@ jobs:
       - name: Build the dogfood host (${{ matrix.tfm }})
         shell: bash
         run: |
-          # The host's post-build codegen target shells out to
-          # `dotnet run --no-build --project Vidra.CodeGen`, which requires the
-          # tool to already be built — true after a solution build, not in a
-          # clean checkout. Build it first so this step tests the host rather
-          # than that ordering quirk.
-          dotnet build src/tools/Vidra.CodeGen/Vidra.CodeGen.csproj -c Debug
+          # No preparatory build of Vidra.CodeGen: the host's post-build codegen
+          # runs the tool with `--no-build`, and ordering that is the host's own
+          # job (it carries a build-order ProjectReference to the tool). Wiping
+          # the tool's Debug output first keeps this a clean-checkout test even
+          # if some earlier step in this job starts building it.
+          rm -rf src/tools/Vidra.CodeGen/bin/Debug
           dotnet build src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj \
             -c Debug -f ${{ matrix.tfm }}
+
+      # This build is what regenerates the SDK's committed built-in contracts,
+      # so it is also the only place drift in them can be caught. macOS only:
+      # the runner checks out with autocrlf, the generator writes LF, and every
+      # regenerated file would read as modified on Windows.
+      - name: Built-in contracts are unchanged by the dogfood build
+        if: runner.os == 'macOS'
+        shell: bash
+        run: git diff --exit-code -- src/sdk/vidra-js/src/generated
 
       - name: Pack local NuGet feed
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ obj/
 *.DotSettings.user
 .vs/
 TestResults/
+# Scratch output of AggregateScope.proj; removed on success, left behind on failure
+tests/dotnet/Vidra.CodeGen.AppFixture/generated-aggregate/
 BenchmarkDotNet.Artifacts/
 *.received.*
 *.coverage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,6 +159,6 @@ export class FilesystemProxy {
 
 Enums cross the wire as their **camelCase string name**, not a numeric value. Native serialization and generated AOT codecs share that policy, so JSON matches the generated string-literal unions. Nullable values (`int?`, `string?`) are omitted when null, which the emitter reflects as optional `field?: T | null`.
 
-Built-in contracts are generated into the SDK. App and opted-in third-party contracts are generated into the app’s configured `VidraTsOutputDir` by the packaged `buildTransitive` target. Generated output is deterministic and committed; `VidraCodeGenCheck` fails CI when it is stale.
+Built-in contracts are generated into the SDK. App and opted-in third-party contracts are generated into the app’s configured `VidraTsOutputDir` by the packaged `buildTransitive` target. Both go through the same `Vidra.CodeGen.targets`: a project scans its own output by default, or lists `VidraCodeGenAssembly` items to aggregate several assemblies into one barrel — which is how the dogfood host regenerates the SDK’s built-in contracts under `VidraContractScope=core`. Generated output is deterministic and committed; `VidraCodeGenCheck` fails CI when it is stale.
 
 At WebView startup, protocol version 2 compares separate core and app manifest fingerprints. A mismatched SDK, native package set, or committed app output fails visibly before bridge traffic starts. The supported claim is therefore: **end-to-end typed contracts, with an explicit unsafe escape hatch**.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,9 +36,11 @@ We follow a pyramid:
 | Contract    | Same fixtures via SDK `contract.test.ts`                    | `ubuntu-latest`       |
 | Integration | CLI `scaffold.integration.test.ts` (tmpdir scaffold)        | `ubuntu-latest`       |
 | Integration | `Vidra.CodeGen.AppFixture` build + `VidraCodeGenCheck`      | `ubuntu-latest`       |
+| Integration | `AggregateScope.proj` — multi-assembly, core-scope codegen  | `ubuntu-latest`       |
 | Smoke       | `tests/dotnet/Vidra.Bridge.Smoke` + `tests/smoke/echo-ping.mjs` | `windows-latest`, `macos-latest` |
 | Smoke       | CLI scaffold + `dotnet build` of scaffolded host            | `windows-latest`, `macos-latest` |
 | Smoke       | Dogfood host (`src/host/Vidra.Host.Maui`) build             | `windows-latest`, `macos-latest` |
+| Smoke       | Dogfood host build leaves the committed built-in contracts unchanged | `macos-latest` |
 | Smoke       | `vidra build` → signature, hardened runtime + entitlements  | `windows-latest`, `macos-latest` |
 | Smoke       | **Runtime E2E** — launch the packaged app, assert a C#↔JS round-trip | `windows-latest`, `macos-latest` |
 | Smoke       | **Dev loop** — `vidra dev` starts, Vite serves, the host builds under `dotnet watch` | `macos-latest` |
@@ -66,6 +68,7 @@ dotnet test tests/dotnet/Vidra.Bridge.Tests/Vidra.Bridge.Tests.csproj
 dotnet test tests/dotnet/Vidra.CodeGen.Tests/Vidra.CodeGen.Tests.csproj
 dotnet build tests/dotnet/Vidra.CodeGen.AppFixture/Vidra.CodeGen.AppFixture.csproj
 dotnet msbuild tests/dotnet/Vidra.CodeGen.AppFixture/Vidra.CodeGen.AppFixture.csproj -t:VidraCodeGenCheck
+dotnet msbuild tests/dotnet/Vidra.CodeGen.AppFixture/AggregateScope.proj -t:VerifyAggregateCodeGen
 dotnet test tests/dotnet/Vidra.Modules.FileSystem.Tests/Vidra.Modules.FileSystem.Tests.csproj
 dotnet test tests/dotnet/Vidra.Modules.Windowing.Tests/Vidra.Modules.Windowing.Tests.csproj
 dotnet test tests/dotnet/Vidra.Modules.Essentials.Tests/Vidra.Modules.Essentials.Tests.csproj

--- a/src/bridge/Vidra.Bridge/Vidra.CodeGen.targets
+++ b/src/bridge/Vidra.Bridge/Vidra.CodeGen.targets
@@ -11,6 +11,14 @@
       VidraSdkImport        - The import path for @vidra-dev/sdk (default: @vidra-dev/sdk)
       VidraCodeGenProject   - Path to the Vidra.CodeGen.csproj (auto-detected in monorepo)
       VidraGenerateTs       - Set to "false" to disable codegen (default: true)
+      VidraContractScope    - "app" (default) or "core"
+
+    Configurable items (set before the Import):
+      VidraCodeGenAssembly  - Assemblies to scan. Defaults to this project's own
+                              output. A project that aggregates contracts from
+                              several assemblies — the framework's own dogfood
+                              host is the only one today — lists them here
+                              instead of hand-rolling its own Exec.
   -->
 
   <PropertyGroup>
@@ -27,13 +35,39 @@
     <CompilerVisibleProperty Include="VidraContractScope" />
   </ItemGroup>
 
+  <!--
+    Both entry points below scan the same assemblies with the same arguments and
+    differ only in the check flag, so the argument line is built once here. TargetPath
+    is only known once the build is running, which is why the default lands in a
+    target rather than a top-level ItemGroup.
+  -->
+  <Target Name="_VidraCodeGenArguments">
+    <ItemGroup>
+      <VidraCodeGenAssembly Condition="'@(VidraCodeGenAssembly)' == ''" Include="$(TargetPath)" />
+    </ItemGroup>
+    <PropertyGroup>
+      <_VidraCodeGenArgs>generate --assembly @(VidraCodeGenAssembly->'&quot;%(Identity)&quot;', ' ') --output &quot;$(VidraTsOutputDir)&quot; --sdk-import &quot;$(VidraSdkImport)&quot; --scope &quot;$(VidraContractScope)&quot;</_VidraCodeGenArgs>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    Runs when there is something to scan: an explicit assembly list, or this
+    project's own output once it exists. A project whose Build produced no
+    assembly (see MissingAggregateTarget.proj) is skipped rather than failed.
+
+    The condition deliberately reads the item before _VidraCodeGenArguments
+    fills in the default — MSBuild evaluates a target's Condition first and
+    skips its DependsOnTargets entirely when that condition is false, so a
+    condition can never read what its own dependency computes.
+  -->
   <Target Name="VidraCodeGen"
           AfterTargets="Build"
-          Condition="'$(VidraGenerateTs)' == 'true' AND '$(TargetFramework)' != '' AND '$(VidraTsOutputDir)' != '' AND Exists('$(TargetPath)')">
+          DependsOnTargets="_VidraCodeGenArguments"
+          Condition="'$(VidraGenerateTs)' == 'true' AND '$(TargetFramework)' != '' AND '$(VidraTsOutputDir)' != '' AND ('@(VidraCodeGenAssembly)' != '' OR Exists('$(TargetPath)'))">
 
-    <Message Importance="high" Text="[Vidra] Generating TypeScript proxies from $(TargetPath)..." />
+    <Message Importance="high" Text="[Vidra] Generating TypeScript proxies from @(VidraCodeGenAssembly->'%(Filename)', ', ')..." />
 
-    <Exec Command="$(VidraCodeGenCommand) generate --assembly &quot;$(TargetPath)&quot; --output &quot;$(VidraTsOutputDir)&quot; --sdk-import &quot;$(VidraSdkImport)&quot; --scope &quot;$(VidraContractScope)&quot;"
+    <Exec Command="$(VidraCodeGenCommand) $(_VidraCodeGenArgs)"
           WorkingDirectory="$(MSBuildProjectDirectory)"
           IgnoreExitCode="false" />
 
@@ -42,8 +76,9 @@
   </Target>
 
   <Target Name="VidraCodeGenCheck"
-          Condition="'$(VidraGenerateTs)' == 'true' AND '$(TargetFramework)' != '' AND '$(VidraTsOutputDir)' != '' AND Exists('$(TargetPath)')">
-    <Exec Command="$(VidraCodeGenCommand) generate --assembly &quot;$(TargetPath)&quot; --output &quot;$(VidraTsOutputDir)&quot; --sdk-import &quot;$(VidraSdkImport)&quot; --scope &quot;$(VidraContractScope)&quot; --check"
+          DependsOnTargets="_VidraCodeGenArguments"
+          Condition="'$(VidraGenerateTs)' == 'true' AND '$(TargetFramework)' != '' AND '$(VidraTsOutputDir)' != '' AND ('@(VidraCodeGenAssembly)' != '' OR Exists('$(TargetPath)'))">
+    <Exec Command="$(VidraCodeGenCommand) $(_VidraCodeGenArgs) --check"
           WorkingDirectory="$(MSBuildProjectDirectory)"
           IgnoreExitCode="false" />
   </Target>

--- a/src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj
+++ b/src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj
@@ -43,28 +43,53 @@
     <ProjectReference Include="..\Vidra.Host.Maui.Core\Vidra.Host.Maui.Core.csproj" />
   </ItemGroup>
 
-  <!-- Auto-generate TS proxies for all modules after the host builds -->
+  <!--
+    Build-order only: the codegen below runs the tool without building it, so the
+    tool has to already exist. Without this reference the host builds only if
+    something else happened to build the tool first — true after a solution
+    build, false in a clean checkout, where the codegen step died with MSB3073.
+
+    The metadata keeps the tool's own build honest. The host targets a platform
+    TFM and, on Windows and Mac Catalyst, a runtime identifier; letting either
+    flow down to a net10.0 console tool would fail its build or land its output
+    in a RID subdirectory that `dotnet run` (no-build) does not look in.
+    Private/ExcludeAssets keep the tool and its package dependencies out of the
+    app itself — this reference exists purely to order the two builds.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="$(MSBuildThisFileDirectory)..\..\tools\Vidra.CodeGen\Vidra.CodeGen.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"
+                      UndefineProperties="TargetFramework;RuntimeIdentifier;SelfContained"
+                      Private="false"
+                      ExcludeAssets="all" />
+  </ItemGroup>
+
+  <!--
+    Auto-generate TS proxies for all modules after the host builds. This host is
+    the only consumer of the aggregate core-scope codegen, but it goes
+    through the same shipped targets every consumer project imports, so tool
+    resolution has one implementation rather than one per caller.
+  -->
   <PropertyGroup>
     <VidraCodeGenProject>$(MSBuildThisFileDirectory)..\..\tools\Vidra.CodeGen\Vidra.CodeGen.csproj</VidraCodeGenProject>
     <VidraTsOutputDir>$(MSBuildThisFileDirectory)..\..\sdk\vidra-js\src\generated</VidraTsOutputDir>
+    <VidraSdkImport>../singleton.js</VidraSdkImport>
+    <VidraContractScope>core</VidraContractScope>
     <VidraModulesDir>$(MSBuildThisFileDirectory)..\..\modules</VidraModulesDir>
   </PropertyGroup>
 
-  <Target Name="VidraCodeGen" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
-    <ItemGroup>
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.FileSystem\bin\$(Configuration)\net10.0\Vidra.Modules.FileSystem.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.Clipboard\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Clipboard.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.Dialogs\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Dialogs.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.Notifications\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Notifications.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.AppLifecycle\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.AppLifecycle.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.Windowing\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Windowing.dll" />
-      <VidraModuleAssembly Include="$(VidraModulesDir)\Vidra.Modules.Essentials\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Essentials.dll" />
-      <VidraModuleAssembly Include="$(MSBuildThisFileDirectory)..\Vidra.Host.Maui.Core\bin\$(Configuration)\$(TargetFramework)\Vidra.Host.Maui.Core.dll" />
-    </ItemGroup>
+  <ItemGroup>
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.FileSystem\bin\$(Configuration)\net10.0\Vidra.Modules.FileSystem.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.Clipboard\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Clipboard.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.Dialogs\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Dialogs.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.Notifications\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Notifications.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.AppLifecycle\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.AppLifecycle.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.Windowing\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Windowing.dll" />
+    <VidraCodeGenAssembly Include="$(VidraModulesDir)\Vidra.Modules.Essentials\bin\$(Configuration)\$(TargetFramework)\Vidra.Modules.Essentials.dll" />
+    <VidraCodeGenAssembly Include="$(MSBuildThisFileDirectory)..\Vidra.Host.Maui.Core\bin\$(Configuration)\$(TargetFramework)\Vidra.Host.Maui.Core.dll" />
+  </ItemGroup>
 
-    <Message Importance="high" Text="[Vidra] Generating TypeScript proxies..." />
-    <Exec Command="dotnet run --configuration $(Configuration) --no-build --project &quot;$(VidraCodeGenProject)&quot; -- generate --assembly @(VidraModuleAssembly->'&quot;%(Identity)&quot;', ' ') --output &quot;$(VidraTsOutputDir)&quot; --sdk-import &quot;../singleton.js&quot; --scope core"
-          WorkingDirectory="$(MSBuildProjectDirectory)" />
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\bridge\Vidra.Bridge\Vidra.CodeGen.targets" />
 
 </Project>

--- a/tests/dotnet/Vidra.CodeGen.AppFixture/AggregateScope.proj
+++ b/tests/dotnet/Vidra.CodeGen.AppFixture/AggregateScope.proj
@@ -1,0 +1,52 @@
+<Project>
+
+  <!--
+    Aggregate codegen — several assemblies scanned into one barrel in core
+    scope — has exactly one real consumer, src/host/Vidra.Host.Maui, and that
+    host only builds on macOS and Windows. This fixture drives the same path
+    through the shipped targets on the Linux tier, so a break in the
+    multi-assembly command surfaces in the cheap job instead of only in the two
+    platform ones.
+
+    Its inputs are two assemblies the Linux job has already built, both
+    carrying contracts: the app fixture next door (a JS contract) and the
+    FileSystem module tests, which link the module's own source and so expose
+    its native contract without needing the MAUI workload.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Configuration Condition="'$(Configuration)' == ''">Release</Configuration>
+    <VidraTsOutputDir>$(MSBuildThisFileDirectory)generated-aggregate</VidraTsOutputDir>
+    <VidraContractScope>core</VidraContractScope>
+    <VidraSdkImport>../singleton.js</VidraSdkImport>
+    <VidraCodeGenProject>$(MSBuildThisFileDirectory)../../../src/tools/Vidra.CodeGen/Vidra.CodeGen.csproj</VidraCodeGenProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <VidraCodeGenAssembly Include="$(MSBuildThisFileDirectory)../Vidra.Modules.FileSystem.Tests/bin/$(Configuration)/net10.0/Vidra.Modules.FileSystem.Tests.dll" />
+    <VidraCodeGenAssembly Include="$(MSBuildThisFileDirectory)bin/$(Configuration)/net10.0/Vidra.CodeGen.AppFixture.dll" />
+  </ItemGroup>
+
+  <Import Project="../../../src/bridge/Vidra.Bridge/Vidra.CodeGen.targets" />
+
+  <Target Name="_VerifyAggregateInputs">
+    <Error Condition="!Exists('%(VidraCodeGenAssembly.Identity)')"
+           Text="Fixture input missing: %(VidraCodeGenAssembly.Identity). Build the $(Configuration) test projects first." />
+  </Target>
+
+  <Target Name="VerifyAggregateCodeGen" DependsOnTargets="_VerifyAggregateInputs;VidraCodeGen">
+
+    <!-- One proxy per scanned assembly proves every assembly argument arrived. -->
+    <Error Condition="!Exists('$(VidraTsOutputDir)/filesystem.ts')"
+           Text="Aggregate codegen dropped the FileSystem module's contract." />
+    <Error Condition="!Exists('$(VidraTsOutputDir)/counter.ts')"
+           Text="Aggregate codegen dropped the app fixture's contract." />
+    <Error Condition="!Exists('$(VidraTsOutputDir)/index.ts')"
+           Text="Aggregate codegen emitted no barrel." />
+
+    <RemoveDir Directories="$(VidraTsOutputDir)" />
+
+  </Target>
+
+</Project>


### PR DESCRIPTION
Fixes #2.

## Summary

`dotnet build src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj` failed on a fresh clone with MSB3073: the host's post-build codegen runs the generator with `--no-build`, so the tool has to exist already — true after a solution build, false in a clean checkout. The host now declares that dependency instead of relying on someone else having satisfied it, and CI stops papering over it with a preparatory `dotnet build` of the tool.

The second half of the fix is the divergence that produced the bug: the host hand-rolled its own `Exec` rather than importing the shipped `Vidra.CodeGen.targets`, so the shipped path's tool resolution never reached the one project that needed it most. Both now run the same targets.

## The bug

```
Unhandled exception: An error occurred trying to start process
  '.../src/tools/Vidra.CodeGen/bin/Debug/net10.0/Vidra.CodeGen' ... No such file or directory
error MSB3073: The command "dotnet run --configuration Debug --no-build --project ".../Vidra.CodeGen.csproj" ..." exited with code 1.
```

Nothing in CI built the dogfood host until #3 added that step, and it worked around the ordering rather than reporting it — so the hidden requirement stayed hidden.

## What changed

**`src/host/Vidra.Host.Maui` gets a build-order `ProjectReference` to `Vidra.CodeGen`** — `ReferenceOutputAssembly="false"`, which is candidate fix (1) from the issue. The metadata is load-bearing rather than defensive boilerplate: the host targets a platform TFM and, on Windows and Catalyst, a runtime identifier. Letting `TargetFramework` flow down fails the net10.0 tool's build outright; letting `RuntimeIdentifier` flow down lands its output in a RID subdirectory that `dotnet run` (no-build) does not look in — the same MSB3073, one layer deeper. `SkipGetTargetFrameworkProperties` + `UndefineProperties` prevent both; `Private="false"` / `ExcludeAssets="all"` keep the tool and its `System.Reflection.MetadataLoadContext` dependency out of the app.

**The host's inline codegen target is gone**; it imports `Vidra.CodeGen.targets` like every other consumer. The shipped targets learned an optional `VidraCodeGenAssembly` item list — defaulting, exactly as before, to the importing project's own `TargetPath` — and the host supplies its eight module assemblies through it, with `VidraContractScope=core` and `VidraSdkImport=../singleton.js` as properties. Same tool, same arguments, one implementation. Both entry points (`VidraCodeGen`, `VidraCodeGenCheck`) now build their argument line in one place instead of two.

**Aggregate codegen gets coverage that doesn't need macOS or Windows.** It had exactly one consumer, the dogfood host, which only builds on the two platform runners — so a break in the multi-assembly path had no cheap detector. `tests/dotnet/Vidra.CodeGen.AppFixture/AggregateScope.proj` drives the same path on the Linux tier over two assemblies the job already builds, and asserts one proxy per assembly plus a barrel.

**CI stops hiding the bug and starts proving the fix.** The dogfood step drops its preparatory tool build and wipes `src/tools/Vidra.CodeGen/bin/Debug` first, so it stays a clean-checkout test even if some future step in that job starts building the tool. A new macOS-only step asserts the dogfood build leaves the SDK's committed built-in contracts byte-identical — that build is what regenerates them, so it is the only place drift in them can surface. (macOS only because the Windows runner checks out with autocrlf while the generator writes LF, which would make every regenerated file read as modified.)

## Verification

Green on all three jobs, run on this branch: [30414527576](https://github.com/horatiuvlad/vidra-upstream/actions/runs/30414527576).

The load-bearing evidence is the dogfood step itself: with the tool's `bin/Debug` wiped and no preparatory build, both platform jobs report

```
[Vidra] Generating TypeScript proxies from Vidra.Modules.FileSystem, ... Vidra.Host.Maui.Core...
Found 19 contract(s):
```

— 19 contracts, the issue's stated expectation, on `net10.0-maccatalyst` and `net10.0-windows10.0.19041.0`, followed by a clean `git diff` over `src/sdk/vidra-js/src/generated`.

Locally on Linux, where neither platform TFM builds, the two mechanisms were checked separately against the real code:

- **Ordering.** A host-shaped project (RID set, aggregate item list, the shipped targets, the build-order reference) builds the real `Vidra.CodeGen` and runs the real aggregate codegen with the tool's output wiped. Removing only the `ProjectReference` from that project reproduces the issue's MSB3073 verbatim — so the reference is what fixes it, not some incidental build.
- **Equivalence.** The old hand-rolled command and the new targets-driven one, over the same two assemblies with `--scope core`, produce byte-identical output (`diff -r`).
- Both existing codegen gates still pass unchanged, including `MissingAggregateTarget.proj`, whose whole point is that the target no-ops rather than fails when a project produced no assembly.

One MSBuild detail is worth recording, because the obvious implementation is wrong: **a target's `Condition` is evaluated before its `DependsOnTargets` run, and a false condition skips the dependencies entirely.** The first draft computed "did the consumer supply assemblies?" in the dependency and read it in the condition, which silently disabled codegen everywhere. Measured with a two-target scratch project, then fixed by having the condition read the item directly — before the dependency fills in the default.

## What this does not cover

The issue lists two more candidate fixes — reusing the shipped targets' resolution logic (done here) and dropping `--no-build` (deliberately not: the ordering is now declared, so a redundant build on every host build buys nothing). `Vidra.Bridge.csproj`'s `BuildVidraCodeGenPackAssets` still shells out to `dotnet build` for its pack assets; that runs `BeforeTargets="GenerateNuspec"` against projects of a different shape and is left alone.


