### PR TITLE
Get the GitHub Actions pins off the retired node20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: |
             src/cli/create-vidra-app/package-lock.json
@@ -260,7 +260,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: |
             src/cli/create-vidra-app/package-lock.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             10.0.x
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -62,7 +62,7 @@ jobs:
       # the project files, so a hit makes every later restore in the job (the
       # dogfood host, pack-local.sh, the scaffolded app) essentially free.
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', 'pack-local.sh') }}
@@ -258,7 +258,7 @@ jobs:
             10.0.x
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: "npm"
@@ -271,7 +271,7 @@ jobs:
       # the project files, so a hit makes every later restore in the job (the
       # dogfood host, pack-local.sh, the scaffolded app) essentially free.
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Build.props', 'pack-local.sh') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x
@@ -249,10 +249,10 @@ jobs:
     # headless runner can never answer.
     timeout-minutes: 100
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dotnet-trx
           path: "**/TestResults/*.trx"
@@ -647,7 +647,7 @@ jobs:
 
       - name: Upload OTA proofs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ota-proofs-${{ matrix.os }}
           path: ${{ runner.temp }}/ota-work/*.json
@@ -804,7 +804,7 @@ jobs:
 
       - name: Upload native-update proofs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-update-proofs-${{ matrix.os }}
           path: |
@@ -819,7 +819,7 @@ jobs:
       # would bury an earlier real failure under a second, confusing one.
       - name: Upload packaged installer
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vidra-installer-${{ matrix.os }}
           path: ${{ runner.temp }}/vidra-smoke/dist/*

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
           cache-dependency-path: |

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -49,7 +49,7 @@ jobs:
       # published tarball and the commit + workflow that produced it.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -89,7 +89,7 @@ jobs:
             10.0.x
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -43,10 +43,10 @@ jobs:
             artifact: nupkgs-windows
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x
@@ -80,10 +80,10 @@ jobs:
     needs: pack
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             10.0.x

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -69,7 +69,7 @@ jobs:
         run: ./pack-local.sh
 
       - name: Upload per-OS packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: dist/packages/*.nupkg
@@ -93,14 +93,18 @@ jobs:
         with:
           python-version: "3.x"
 
+      # Both halves of the handoff are by name, which is the case the artifact
+      # actions have kept stable across majors: the v5 path change applied to
+      # downloads by artifact-ids, and the digest check v8 promotes from warning
+      # to error is a check on our own upload from the pack job.
       - name: Download macOS packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nupkgs-macos
           path: pkg-macos
 
       - name: Download Windows packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nupkgs-windows
           path: pkg-windows
@@ -109,7 +113,7 @@ jobs:
         run: python3 scripts/merge-nupkgs.py --inputs pkg-macos pkg-windows --output merged
 
       - name: Upload merged packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nupkgs-merged
           path: merged/*.nupkg

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -32,7 +32,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "24"
 
       # A bump on top of an already-inconsistent tree would bury the drift in a
       # release commit, so refuse before touching anything.


### PR DESCRIPTION
Closes #8 — every run today is annotated because the `@v4` pins declare `runs: node20`, a runtime GitHub is retiring.

| | was | now |
|---|---|---|
| `checkout` · `setup-dotnet` | v4 · v4 | **v7** · **v6** |
| `setup-node` · `cache` · `setup-python` | v4 · v4 · v5 | **v7** · **v6** · **v7** |
| `upload-artifact` · `download-artifact` | v4 · v4 | **v7** · **v8** |
| `node-version` | "20" | **"24"** |

**Three things to know:**

1. **Current majors, not the `@v5` waypoint I suggested in the issue.** Nothing between v4 and now touches an input this repo passes, so stopping short would just mean doing it again.
2. **One commit per group from the issue's split** — drop any group without disturbing the others. The last commit, Node 20 → 24, is **beyond the issue's scope**: that's the Node *our own scripts* run on, and 20 left support in April. Drop that commit alone if you'd rather decide it separately.
3. **All four workflows were run on the fork, not just CI** — [CI](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762198712) ✅ · [Release NuGet dry run](https://github.com/horatiuvlad/vidra-fork/actions/runs/30761835691) ✅ · [Release npm dry run](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762993700) ✅. The NuGet one matters most: it hands artifacts between jobs, which the issue rightly called the part that wants reading rather than a find-and-replace.

**The annotation is measurably gone.** Upstream's [`Release NuGet` publish yesterday](https://github.com/rzamfiriu/vidra/actions/runs/30756112807) shows it on every job; the same workflow on this branch shows nothing beyond the pre-existing `DisplayAlert` warnings.

**One caveat worth your attention:** `version-bump.yml` can't complete on a fork. Its `git push` works (that's the step `checkout@v6` could have broken), but `gh pr create` then fails — the repo setting *"Allow GitHub Actions to create and approve pull requests"* is off by default and governs the run's `GITHUB_TOKEN`. Unrelated to these pins, but that workflow has **no runs upstream either**, so its last step is unproven for you too.

<details>
<summary><b>Detail: what each major between v4 and now actually changed</b></summary>

- **checkout v5 → v6 → v7.** v5 is the node24 move; v6 persists the credential into its own config file referenced by `includeIf.gitdir` instead of `.git/config`; v7 blocks checking out a fork PR under `pull_request_target` / `workflow_run`, neither of which this repo uses. The credential change is the one that could plausibly bite, in `version-bump.yml`.
- **setup-node v5 → v6 → v7.** v5 added automatic caching driven by the `packageManager` field in `package.json`, narrowed to npm in v6. No `package.json` here declares that field, and every call site already passes `cache: npm` with an explicit `cache-dependency-path`, so it has nothing to act on.
- **cache v5 → v6** and **setup-dotnet v5 → v6**: node24, then ESM. Keys and inputs untouched.
- **upload-artifact v5 → v7.** v7 adds unarchived single-file uploads behind `archive: false`, which defaults off; all five uploads here are globs, and every artifact name is already unique per run.
- **download-artifact v5 → v8.** v5's breaking path change applies to downloads **by `artifact-ids`**; both downloads in `release-nuget.yml` are **by name**, which extracted straight into `path` before and still does. v8 promotes a digest mismatch from warning to error — here that's a check on an upload the same run produced.
- **setup-python v6 → v7.** node24, then the removal of the `pip-install` input, which this repo never passed.
- **`maxim-lobanov/setup-xcode@v1`** needed no change — it already resolves to a `node24` release, which is why it never appeared in an annotation.

</details>

<details>
<summary><b>Detail: verification, and the three things it does not prove</b></summary>

| run | covers |
|---|---|
| [CI](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762198712) ✅ | ubuntu + windows + macOS, both packaging legs and both update tiers, on Node v24.18.0 |
| [Release NuGet (dry run)](https://github.com/horatiuvlad/vidra-fork/actions/runs/30761835691) ✅ | the CI gate, then pack ×2 → `download-artifact@v8` → merge → `upload-artifact@v7` |
| [Release npm (dry run)](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762993700) ✅ | the CI gate, then the publish job under `setup-node@v7` with `registry-url` |
| [Bump version](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762201750) | the `git push` of the release branch under `checkout@v7` |

The exact annotation on upstream's runs, for comparison:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/cache@v4`, `actions/checkout@v4`, `actions/setup-dotnet@v4`, `actions/setup-node@v4`, `actions/upload-artifact@v4`.

What the runs above do **not** establish:

- **Publishing itself.** Both release workflows ran with `push=false`; npm and nuget.org refuse to re-publish a version, so a dry run is as far as any test can go.
- **`npm publish --dry-run`'s own body.** Both packages resolved to `0.4.0`, already on the registry, so `npm-publish.sh` reported "nothing to do" and returned. The run proves `setup-node@v7` produces a working `.npmrc` and that the registry check runs on npm 11.
- **`version-bump.yml`'s final step**, as described above.

</details>

<details>
<summary><b>Unrelated, but noticed while testing</b></summary>

`release-nuget.yml` still pins `xcode-version: "26.3"` and passes `--skip-manifest-update`, with a comment about the image topping out below what the maccatalyst manifest wants. `ci.yml` deleted that exact pin in 6b65a8c because the image moved to Xcode 26.6 and the pin inverted into a linker failure — so the two files now disagree about the same fact. The macOS pack leg still passes with it, so this is inconsistency rather than breakage. Happy to fix it in a separate PR.

</details>
