### PR TITLE
Upload the installer that CI actually verified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,6 +572,33 @@ jobs:
           ./tests/ci/launch-windows-app.ps1 -Zip "$env:ARTIFACT" `
             -Cli "$env:GITHUB_WORKSPACE/src/cli/create-vidra-app/dist/cli.js"
 
+      # Uploaded here, while dist/ still holds exactly one file, rather than at
+      # the end of the job. Everything below builds the same scaffold again into
+      # the same dist/ and nothing ever cleans it (the OTA rebuild, then 1.0.0
+      # and 1.0.1 with Velopack's accumulating feed), so uploading at the end
+      # shipped every copy at once: 804 MB on Windows and 216 MB on macOS to
+      # carry one 88 MB / 33 MB installer. Worse, the OTA rebuild below
+      # overwrites this very filename, so that artifact carried bytes no step
+      # had signature-checked or launched. From here it carries the file the
+      # verify-and-launch steps above just ran, and nothing between them and
+      # this step writes into dist/: the launch scripts stage into their own
+      # temp directories. The update-enabled rebuild is deliberately not
+      # uploaded, since the OTA round-trip runs the binary from bin/Release and
+      # never anything in dist/, so that file was never the thing under test.
+      #
+      # Still uploaded on failure, since a broken installer is worth inspecting.
+      # Staying lenient here is deliberate: the strict gate is the
+      # "Verify a distributable artifact was produced" step above, which asserts
+      # exactly one artifact of the expected type. Making the upload strict too
+      # would bury an earlier real failure under a second, confusing one.
+      - name: Upload packaged installer
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vidra-installer-${{ matrix.os }}
+          path: ${{ runner.temp }}/vidra-smoke/dist/*
+          if-no-files-found: ignore
+
       # ---- Over-the-air bundle updates ----
       #
       # A second build of the same scaffold, configured for updates and driven
@@ -807,20 +834,21 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: native-update-proofs-${{ matrix.os }}
+          # The whole feed index, not just releases.<channel>.json: RELEASES* is
+          # Velopack's legacy client index and assets.<channel>.json its upload
+          # manifest, and "the feed is malformed for an older client" is a
+          # different failure from "the JSON is wrong". The whole index is about
+          # 1.2 KB. The delta comes along because Windows is the leg
+          # that applies it (`feed 200 com.vidra.smoke-1.0.1-delta.nupkg`, 255
+          # KB against a 94 MB full package), and it is the one feed file the
+          # `ls -la dist/release` above cannot show you the inside of. Catalyst
+          # applies the full package instead, so on macOS the delta is evidence
+          # about what the feed published rather than about the bytes that were
+          # applied. The full packages stay out at 32-94 MB each; their sizes
+          # and SHA256s are already in releases.<channel>.json.
           path: |
             ${{ runner.temp }}/native-work/*
-            ${{ runner.temp }}/vidra-smoke/dist/release/releases*.json
-          if-no-files-found: ignore
-
-      # Uploaded even on failure, since a broken installer is worth inspecting.
-      # Staying lenient here is deliberate: the strict gate is the
-      # "Verify a distributable artifact was produced" step above, which asserts
-      # exactly one artifact of the expected type. Making the upload strict too
-      # would bury an earlier real failure under a second, confusing one.
-      - name: Upload packaged installer
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: vidra-installer-${{ matrix.os }}
-          path: ${{ runner.temp }}/vidra-smoke/dist/*
+            ${{ runner.temp }}/vidra-smoke/dist/release/*.json
+            ${{ runner.temp }}/vidra-smoke/dist/release/RELEASES*
+            ${{ runner.temp }}/vidra-smoke/dist/release/*delta.nupkg
           if-no-files-found: ignore


### PR DESCRIPTION
`Upload packaged installer` is the Smoke job's last step, and it globs `dist/*`. That was exactly one file when the step was written. Since then three more builds landed above it in the same job, writing into the same `dist/`: the OTA rebuild from #7, then the `--native-update` 1.0.0 / 1.0.1 pair from #9. Nothing cleans between them, and nothing should, because `dist/release/` **is** the Velopack feed the deltas and the rollback depend on.

Nothing is broken today and no test asserts anything false: the update-enabled rebuild is a legitimate step and the checks above it are real. It is the artifact name that lies.

**1. The uploaded installer is not the installer CI verified.** `Rebuild the app with updates enabled`, further down the job, rewrites the same filename the gate, the signature check and the launch test all ran against:

| leg | gate + signature + launch ran against | artifact shipped |
|---|---|---|
| windows | `VidraSmoke-1.2.3-windows.zip`, **88,143,692 B** | **88,149,926 B** |
| macos | `VidraSmoke-1.2.3-macos.dmg`, **32,996,838 B** | **32,332,727 B** |

Nothing signature-checked or launched the bytes a maintainer can download.

**2. Size, second.** The Windows artifact is 842,587,390 B (804 MiB) across 13 files, macOS 226,851,781 B (216 MiB) across 11. The one verified installer is 10.5% of the Windows artifact; 193,421,105 B of the rest is byte-for-byte duplication. That is what sent me to the step; the mismatch above is what I found there. Measured on [run 30762198712](https://github.com/horatiuvlad/vidra-fork/actions/runs/30762198712).

## The fix is a move, not a narrower path

The step goes immediately after the verify-and-launch steps, where `dist/` still holds exactly one file (both legs' logs agree: `total 86084` on Windows, `total 66488` on macOS, one entry each). Name, glob, `if: always()` and `if-no-files-found: ignore` are all untouched, so a broken installer is still captured on failure; most of the +42 is comment. Narrowing the path instead would have kept the artifact pointing at whichever build wrote last.

Second hunk, the native-update proofs: `releases*.json` never matched `RELEASES` / `RELEASES-osx` (Velopack's legacy client index) or `assets.win.json` / `assets.osx.json` (its upload manifest). Those only ever reached an artifact through the fat `dist/*` glob, so shrinking without this would silently drop them. That path now takes `*.json`, `RELEASES*` and `*delta.nupkg`: two more index files at 457 B on Windows and 473 B on macOS, plus the delta (about 250 KB on Windows, about 175 KB on macOS). It is the one place this PR adds files rather than removing them.

## What this deliberately stops shipping, and the one call for you

The Velopack `Setup.exe` / `Setup.pkg`, the portable zips and the full `.nupkg`s stop being downloadable, including on macOS, the leg ci.yml itself calls "the leg that can still fail". Their names, sizes and SHA256s stay in `releases.<channel>.json`, and the `ls -la dist dist/release` and `ls -la dist/release` steps still print the directory.

The claim that this is safe rests on how packaging failures have actually been debugged in this repo: in-CI probe rounds and `os_log` reads, visible in #9's own history, not by downloading an artifact after the fact. If you would rather have belt and braces, the cheap version is a second upload under its own name, `if: failure()`, still `dist/*`: zero bytes on green runs, full forensics on red ones. I left it out to keep this a pure move, and it is a two-line addition if you want it.

## Verification

Dispatched on the fork at this branch's head, `0f4d0be`: [run 30780365237](https://github.com/horatiuvlad/vidra-fork/actions/runs/30780365237), all three jobs green.

| artifact | before | after |
|---|---|---|
| `vidra-installer-windows-latest` | 842,587,390 B, 13 files | **87,032,485 B, 1 file** |
| `vidra-installer-macos-latest` | 226,851,781 B, 11 files | **30,268,135 B, 1 file** |
| `native-update-proofs-windows-latest` | 4,326 B, 7 files | 87,231 B, 10 files |
| `native-update-proofs-macos-latest` | 4,398 B, 7 files | 29,665 B, 10 files |

That the uploaded file is the verified one is checkable rather than asserted: the gate logged `VidraSmoke-1.2.3-windows.zip` at 88,143,674 B, and `unzip -l` on the downloaded artifact shows that exact size as its only entry (macOS: 32,996,675 B, matching too). On the run this PR describes, those two numbers differed.

<details>
<summary><b>Detail: where the 804 MiB comes from</b></summary>

Four builds write into `${{ runner.temp }}/vidra-smoke/dist/` over the life of the Smoke job, in this order:

| step | writes |
|---|---|
| `Package the scaffolded app` | the installer that gets verified and launched |
| `Rebuild the app with updates enabled` | **the same filename again**, different bytes |
| `Build and pack 1.0.0` | full package + `Setup` + portable into `dist/release/`, plus `VidraSmoke-1.0.0-windows.zip` and `VidraSmoke-1.0.0-Setup.exe` into `dist/` itself |
| `Build and pack 1.0.1` | the same again, plus the delta, merged into the same feed |

On Windows two of those pairs are byte-for-byte identical:

| pair | size, each |
|---|---|
| `VidraSmoke-1.0.1-windows.zip` == `com.vidra.smoke-win-Portable.zip` | 94,475,537 B |
| `VidraSmoke-1.0.1-Setup.exe` == `com.vidra.smoke-win-Setup.exe` | 98,945,568 B |

193,421,105 B of the Windows artifact, carried on every green run, so that a maintainer can download a copy of a file already in the artifact under another name.

That duplication is not a bug in `vpk`, and it is not accidental. `vpk pack` names its output by pack id into `dist/release/`; `vidra build` then republishes the portable zip and `Setup.exe` into `dist/` under the app-and-version names it already promises, in `stepPublishVelopackWindowsArtifacts` (`src/cli/create-vidra-app/src/commands/build.ts`), precisely because `vpk` overwrites the unversioned `Setup.exe` on every release. macOS has no such pair, because Vidra does not republish anything there, so the 193,421,105 B figure is Windows-only.

One unit note: 842,587,390 B is the compressed size the artifacts API reports, while the per-file figures above are uncompressed, so the percentage is approximate.

</details>

<details>
<summary><b>Detail: why the path stays a glob rather than <code>${{ env.ARTIFACT }}</code></b></summary>

`ARTIFACT` is set by `Verify a distributable artifact was produced`. On an early failure it expands to empty, and `upload-artifact` rejects an empty `path` outright: a second, confusing failure stacked on the real one, on exactly the run where you want the upload to be quiet. `if-no-files-found: ignore` covers a glob that matches nothing, so the lenient pair keeps working the way the step's existing comment says it should: the strict gate is that step above, not the upload.

</details>

<details>
<summary><b>Detail: nothing writes into dist/ between the launch test and the new upload position</b></summary>

This is the claim the whole fix rests on, so: the two launch scripts stage outside `dist/`. `tests/ci/launch-macos-app.sh` mounts and copies into `mktemp -d` directories, and `tests/ci/launch-windows-app.ps1` expands into `$env:RUNNER_TEMP/vidra-e2e-<random>`. The file uploaded is the file that was just signature-checked and run.

The update-enabled rebuild is not uploaded, and that is intentional rather than an oversight: the OTA round trip runs the binary out of `bin/Release` and publishes its feed into `${{ runner.temp }}/ota-work`, never touching anything in `dist/`. That file was never the thing under test. It was only ever in the artifact because it happened to overwrite a name.

</details>

<details>
<summary><b>Detail: what the proofs upload now takes</b></summary>

`*.json` + `RELEASES*` + `*delta.nupkg` from `dist/release/`, alongside the existing `native-work/*`.

The whole index rather than just `releases.<channel>.json`, because "the feed is malformed for an older client" is a different failure from "the JSON is wrong", and the whole index is about 1.2 KB. The delta comes along because Windows is the leg that applies it, 255,117 B against a 94 MB full package (174,945 B on macOS), and it is the one feed file that the `ls -la dist/release` step cannot show you the inside of. Catalyst applies the full package instead, so on macOS the delta is evidence about what the feed published rather than about the bytes that were applied. The full packages stay out at 32-94 MB each.

</details>