### PR TITLE
The lockfiles carry the version too, so derive them

### DIFF
--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -22,6 +22,14 @@ const SOURCE = path.join(ROOT, "version.json");
 
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
 
+/** Both places an npm lockfile names its own package's version. */
+const writeLockVersion = (source, version) => {
+  const lock = JSON.parse(source);
+  lock.version = version;
+  if (lock.packages?.[""]) lock.packages[""].version = version;
+  return `${JSON.stringify(lock, null, 2)}\n`;
+};
+
 /** Files that carry a copy of the version, and how to read/write it. */
 const derived = [
   {
@@ -41,6 +49,22 @@ const derived = [
     file: "src/cli/create-vidra-app/src/theme.ts",
     read: (s) => s.match(/CLI_VERSION = "([^"]+)"/)?.[1],
     write: (s, v) => s.replace(/(CLI_VERSION = ")[^"]+(")/, `$1${v}$2`),
+  },
+  {
+    // A lockfile records the version of the package it locks, in two places.
+    // `npm ci` does not mind if they disagree with package.json and the
+    // published tarball takes its version from package.json either way — so
+    // this drifts silently, which is the one thing version.json exists to stop.
+    // Rewritten by round-trip because npm's own formatting is exactly
+    // JSON.stringify(…, 2) plus a newline.
+    file: "src/cli/create-vidra-app/package-lock.json",
+    read: (s) => JSON.parse(s).version,
+    write: (s, v) => writeLockVersion(s, v),
+  },
+  {
+    file: "src/sdk/vidra-js/package-lock.json",
+    read: (s) => JSON.parse(s).version,
+    write: (s, v) => writeLockVersion(s, v),
   },
   {
     // Every packable csproj resolves <Version> through this property, so the

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -30,6 +30,20 @@ const writeLockVersion = (source, version) => {
   return `${JSON.stringify(lock, null, 2)}\n`;
 };
 
+/**
+ * Read both, and report the disagreement rather than the root value when they
+ * differ — otherwise `check` passes on a lockfile that names two versions of
+ * itself, which is the drift this is here to catch.
+ */
+const readLockVersion = (source) => {
+  const lock = JSON.parse(source);
+  const inner = lock.packages?.[""]?.version;
+  if (inner !== undefined && inner !== lock.version) {
+    return `${lock.version} at the root, ${inner} under packages[""]`;
+  }
+  return lock.version;
+};
+
 /** Files that carry a copy of the version, and how to read/write it. */
 const derived = [
   {
@@ -58,13 +72,13 @@ const derived = [
     // Rewritten by round-trip because npm's own formatting is exactly
     // JSON.stringify(…, 2) plus a newline.
     file: "src/cli/create-vidra-app/package-lock.json",
-    read: (s) => JSON.parse(s).version,
-    write: (s, v) => writeLockVersion(s, v),
+    read: readLockVersion,
+    write: writeLockVersion,
   },
   {
     file: "src/sdk/vidra-js/package-lock.json",
-    read: (s) => JSON.parse(s).version,
-    write: (s, v) => writeLockVersion(s, v),
+    read: readLockVersion,
+    write: writeLockVersion,
   },
   {
     // Every packable csproj resolves <Version> through this property, so the

--- a/src/cli/create-vidra-app/package-lock.json
+++ b/src/cli/create-vidra-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-vidra-app",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-vidra-app",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",


### PR DESCRIPTION
`version.json` is the single source of truth for the version, and `scripts/version.mjs` rewrites every file that carries a copy of it. It rewrites five files today and misses two.

Both `package-lock.json` files name the version of the package they lock, twice each: once at the root and once under `packages[""]`. Nothing rewrote them and nothing checked them.

It has already gone wrong. `src/cli/create-vidra-app/package-lock.json` says **0.3.1** while its `package.json` says 0.4.0.

### Why nobody noticed

Nothing breaks loudly. `npm ci` does not mind the disagreement, and the published tarball takes its version from `package.json` either way, so the only symptom is that a lockfile gives the wrong answer to "what version is this". That is the same shape as the `CLI_VERSION` constant that sat at 0.3.1 while the package said 0.4.0, and it gets the same fix: derive it, and let `version.mjs check` fail on drift.

### The change

Three lines of `scripts/version.mjs`, plus a `write` helper. Both lockfiles join the derived list.

The rewrite is a JSON round trip rather than a regex, because npm's own formatting is exactly `JSON.stringify(lock, null, 2)` plus a newline. That was checked byte for byte on both files first, and re-checked after a real `npm install` under npm 10 and npm 11.

A bump now touches two more lines per lockfile and nothing else.

### Timing

Worth landing before the next bump rather than after. `version-bump.yml` runs `version.mjs check` against whatever tree it checks out, so a bump that happens first leaves both lockfiles behind at the old number.
