### PR TITLE
Clear a promoted bundle's probation from the bridge traffic that proves it booted

### DIFF
--- a/src/host/Vidra.Host.Maui.Core/WebViewBridge.cs
+++ b/src/host/Vidra.Host.Maui.Core/WebViewBridge.cs
@@ -135,22 +135,30 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
 
     private async void OnNavigated(object? sender, WebNavigatedEventArgs e)
     {
-        await PushToJsAsync("window.__vidra_native = true");
-
-        var handshake = new BridgeHandshake
-        {
-            ProtocolVersion = BridgeProtocol.Version,
-            CoreFingerprint = BridgeContractRegistry.Fingerprint(BridgeManifestScope.Core),
-            AppFingerprint = BridgeContractRegistry.Fingerprint(BridgeManifestScope.App),
-        };
+        // Both pushes are guarded, and the watcher starts either way. This is an
+        // `async void` event handler, so an escaping exception is an unhandled
+        // one; and on Windows the first push is a real thrower —
+        // EvaluateJavaScriptAsync reports "a valid CoreWebView2 is not present"
+        // when the handler is between platform views, which has been seen on CI.
+        // Letting that skip the watcher would leave a promoted bundle with
+        // nothing to clear its probation.
         try
         {
+            await PushToJsAsync("window.__vidra_native = true");
+
+            var handshake = new BridgeHandshake
+            {
+                ProtocolVersion = BridgeProtocol.Version,
+                CoreFingerprint = BridgeContractRegistry.Fingerprint(BridgeManifestScope.Core),
+                AppFingerprint = BridgeContractRegistry.Fingerprint(BridgeManifestScope.App),
+            };
+
+            // Protocol mismatch handling renders its diagnostic before throwing
+            // in JavaScript; keep the native UI thread alive so it remains visible.
             await PushToJsAsync($"window.__vidra_initialize({BridgeSerializer.Serialize(handshake)})");
         }
         catch (Exception ex)
         {
-            // Protocol mismatch handling renders its diagnostic before throwing
-            // in JavaScript; keep the native UI thread alive so it remains visible.
             System.Diagnostics.Debug.WriteLine(
                 $"[Vidra] Bridge protocol initialization failed: {ex.Message}");
         }

--- a/src/host/Vidra.Host.Maui.Core/WebViewBridge.cs
+++ b/src/host/Vidra.Host.Maui.Core/WebViewBridge.cs
@@ -74,6 +74,11 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
             return;
         }
 
+        // A frame arrived over the native channel, so the bundle's JavaScript has
+        // parsed, run, and constructed the SDK's transport. Nothing weaker than a
+        // booted bundle can produce one.
+        AnnounceBundleBoot();
+
         if (string.Equals(kind, "reverse", StringComparison.OrdinalIgnoreCase))
         {
             HandleReverseResponse(dataJson);
@@ -89,20 +94,44 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
     /// </summary>
     /// <remarks>
     /// This is what clears an updated bundle's probation, so it has to mean
-    /// something a broken bundle cannot fake. It fires when the page has
-    /// installed <c>window.__vidra_initialize</c> — the SDK does that while
-    /// constructing its client, so the bundle's JavaScript has parsed and
-    /// executed and the bridge exists on both sides.
+    /// something a broken bundle cannot fake. Two things say it, and whichever
+    /// happens first wins:
+    /// <list type="bullet">
+    /// <item>a frame arrived from JS — only the SDK's transport sends those, so
+    /// the bundle's JavaScript has parsed, run and reached native;</item>
+    /// <item>the page has installed <c>window.__vidra_initialize</c>, which the
+    /// SDK does while constructing its client. This covers a bundle that boots
+    /// the SDK and never calls into native.</item>
+    /// </list>
     ///
-    /// What it does not prove is that the app rendered anything. A bundle whose
-    /// own code throws after the SDK is up still counts as booted here, and would
-    /// not be rolled back. Closing that gap needs the JS side to say so
-    /// explicitly, which is a bridge contract change and deliberately not in the
-    /// first version.
+    /// The inbound frame is the one that normally fires, and it exists because
+    /// the poll alone was not enough: it takes its first sample a quarter of a
+    /// second after navigation completes, and an app whose page is already
+    /// talking to native by then can finish its work and exit inside that
+    /// window. When that happened the bundle stayed on probation, and two silent
+    /// launches later a perfectly good bundle was rolled back and blocked.
+    ///
+    /// What neither proves is that the app rendered anything. A bundle whose own
+    /// code throws after the SDK is up still counts as booted here, and would not
+    /// be rolled back. Closing that gap needs the JS side to say so explicitly,
+    /// which is a bridge contract change and deliberately not in the first
+    /// version.
     /// </remarks>
     public event Action? BundleBooted;
 
-    private bool _bundleBootAnnounced;
+    private int _bundleBootAnnounced;
+
+    /// <summary>
+    /// Raises <see cref="BundleBooted"/> exactly once, whichever proof arrives
+    /// first and on whichever thread carries it.
+    /// </summary>
+    private void AnnounceBundleBoot()
+    {
+        if (Interlocked.Exchange(ref _bundleBootAnnounced, 1) != 0)
+            return;
+
+        BundleBooted?.Invoke();
+    }
 
     private async void OnNavigated(object? sender, WebNavigatedEventArgs e)
     {
@@ -135,14 +164,17 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
     /// navigation completes: the document is "navigated" before its scripts have
     /// run, so a single check would report every bundle broken.
     /// </summary>
+    /// <remarks>
+    /// The first sample is taken straight away and the wait moved to the end of
+    /// the loop. Sleeping first cost a quarter of a second on every launch, in
+    /// the one place where the app may already have everything it needs to exit.
+    /// </remarks>
     private async Task WatchBundleBootAsync()
     {
         const int attempts = 40;
 
-        for (var attempt = 0; attempt < attempts && !_bundleBootAnnounced; attempt++)
+        for (var attempt = 0; attempt < attempts && Volatile.Read(ref _bundleBootAnnounced) == 0; attempt++)
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(250));
-
             string? answer;
             try
             {
@@ -154,16 +186,18 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
             catch (Exception ex)
             {
                 System.Diagnostics.Debug.WriteLine($"[Vidra] boot probe failed: {ex.Message}");
+                await Task.Delay(TimeSpan.FromMilliseconds(250));
                 continue;
             }
 
             // Platforms disagree about whether a JS string comes back quoted.
-            if (answer?.Trim().Trim('"') != "true")
-                continue;
+            if (answer?.Trim().Trim('"') == "true")
+            {
+                AnnounceBundleBoot();
+                return;
+            }
 
-            _bundleBootAnnounced = true;
-            BundleBooted?.Invoke();
-            return;
+            await Task.Delay(TimeSpan.FromMilliseconds(250));
         }
     }
 
@@ -172,6 +206,7 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
         if (e.Url.StartsWith("vidra://reverse", StringComparison.OrdinalIgnoreCase))
         {
             e.Cancel = true;
+            AnnounceBundleBoot();
             var payload = Uri.UnescapeDataString(e.Url.Substring("vidra://reverse?payload=".Length));
             HandleReverseResponse(payload);
             return;
@@ -181,6 +216,10 @@ public sealed partial class WebViewBridge : IJsCallbackChannel, IUnsafeJsCallbac
             return;
 
         e.Cancel = true;
+
+        // Same claim as the native channel, on the transport platforms fall back
+        // to: only the SDK navigates to vidra://.
+        AnnounceBundleBoot();
 
         var bridgePayload = Uri.UnescapeDataString(e.Url.Substring("vidra://bridge?payload=".Length));
         var response = await _dispatcher.DispatchAsync(bridgePayload);

--- a/src/updates/Vidra.Updates/UpdateClient.cs
+++ b/src/updates/Vidra.Updates/UpdateClient.cs
@@ -108,8 +108,16 @@ public sealed class UpdateClient(BundleStore store, BundleInstaller? installer =
 
             var identity = new BundleIdentity(
                 entry.Version, request.CoreFingerprint, request.AppFingerprint);
+
+            // Re-read rather than write back the snapshot this check started
+            // from. A download takes as long as the network takes, and the
+            // running app is deciding things about the same file the whole time
+            // — clearing the probation on a bundle that has just proved it
+            // boots, most of all. Writing the pre-download copy would put that
+            // probation back, and a resurrected probation is how a working
+            // bundle gets rolled back.
             var updated = UpdateLifecycle.ForgetUnreferenced(
-                UpdateLifecycle.OnDownloaded(state, entry.Sha256, identity));
+                UpdateLifecycle.OnDownloaded(_store.LoadState(), entry.Sha256, identity));
             _store.SaveState(updated);
             _store.Prune(updated);
 

--- a/tests/dotnet/Vidra.Updates.Tests/UpdateClientTests.cs
+++ b/tests/dotnet/Vidra.Updates.Tests/UpdateClientTests.cs
@@ -168,6 +168,61 @@ public sealed class UpdateClientTests : IDisposable
         result.Reason.Should().Contain("already rejected");
     }
 
+    [Fact]
+    public async Task A_boot_confirmed_during_the_download_survives_the_check()
+    {
+        // The running app writes to the same state file the check is about to.
+        // Clearing probation on a bundle that has just proved it boots is the
+        // write that matters: put it back and the bundle is rolled back two
+        // launches later, having done nothing wrong.
+        var feed = PublishFeed(("1.1.0", Core, App));
+        var store = Store();
+        var serving = "a".PadRight(64, 'a');
+        store.SaveState(new UpdateState
+        {
+            Current = serving,
+            CurrentVersion = "1.0.5",
+            Probation = new BundleProbation(serving, 1),
+            Installed = new Dictionary<string, BundleIdentity>(StringComparer.OrdinalIgnoreCase)
+            {
+                [serving] = new("1.0.5", Core, App),
+            },
+        });
+
+        var source = new ConfirmsBootMidDownload(new FileBundleSource(feed), store);
+        var result = await new UpdateClient(store).CheckAsync(source, Request());
+
+        result.Outcome.Should().Be(UpdateCheckOutcome.Downloaded);
+        source.Confirmed.Should().BeTrue("the test only proves anything if the write happened mid-check");
+
+        // Both halves have to hold: what the running app cleared stays cleared,
+        // and the bundle the check downloaded is still staged.
+        store.LoadState().Probation.Should().BeNull();
+        store.LoadState().PendingVersion.Should().Be("1.1.0");
+        result.State!.Probation.Should().BeNull();
+    }
+
+    /// <summary>Clears probation the moment the archive is opened, as a booting bundle would.</summary>
+    private sealed class ConfirmsBootMidDownload(IBundleSource inner, BundleStore store) : IBundleSource
+    {
+        public bool Confirmed { get; private set; }
+
+        public string Description => inner.Description;
+
+        public Task<string> GetManifestAsync(CancellationToken ct = default)
+            => inner.GetManifestAsync(ct);
+
+        public Task<string?> GetManifestSignatureAsync(CancellationToken ct = default)
+            => inner.GetManifestSignatureAsync(ct);
+
+        public Task<Stream> OpenBundleAsync(string url, CancellationToken ct = default)
+        {
+            store.SaveState(UpdateLifecycle.OnBootConfirmed(store.LoadState()));
+            Confirmed = true;
+            return inner.OpenBundleAsync(url, ct);
+        }
+    }
+
     private BundleStore Store() => new(Path.Combine(_work, "appdata"));
 
     private static UpdateCheckRequest Request(string embeddedVersion = "1.0.0")

--- a/tests/smoke/ota-e2e.mjs
+++ b/tests/smoke/ota-e2e.mjs
@@ -85,6 +85,11 @@ try {
   expect(promoted.marker, MARKER, "the updated bundle served");
   expect(promoted.currentVersion, "1.3.0", "current version");
   expectBridge(promoted, "the bridge still works from an updated bundle");
+  // Asserted here, where it happens. A bundle that serves and talks to the
+  // bridge but never clears its probation looks perfectly healthy for two more
+  // launches and is then rolled back — which is how issue #13 spent its life
+  // being reported against the phase three launches further on.
+  expectLog(promoted, "probation cleared", "and its probation is cleared, so it is not rolled back later");
 
   // ---- mismatch: newer, but built against a different contract --------------
   addEntry({
@@ -379,6 +384,7 @@ function launch(name, { timeout = 60 } = {}) {
   }
 
   const proof = JSON.parse(fs.readFileSync(proofPath, "utf8"));
+  proof.output = output;
   console.log(
     `    marker=${proof.marker} current=${proof.currentVersion} ` +
       `pending=${proof.pendingVersion} counter=${proof.counter}`,
@@ -396,6 +402,15 @@ function expect(actual, expected, what) {
   console.log(
     `::error::${what}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
   );
+}
+
+function expectLog(proof, needle, what) {
+  if (proof.output.includes(needle)) {
+    console.log(`    \u2713 ${what}`);
+    return;
+  }
+  failures++;
+  console.log(`::error::${what}: the launch never logged "${needle}"`);
 }
 
 function expectBridge(proof, what = "the bridge completed a round-trip") {


### PR DESCRIPTION
Fixes the intermittent Windows OTA failure in #13.

**The bundle was never rolled back for the reason the test reports.** In the red run, the good 1.3.0 bundle was promoted, served, and completed a bridge round trip, and nothing cleared its probation. Two launches later it ran out of attempts and was rolled back and permanently blocked. The `corrupt` phase, where the failure surfaces, is three launches downstream and its bad-bundle rejection is unrelated.

The missing line, in one CI log:

| launch | logged |
|---|---|
| `promoted` | `promoting bundle a72cec65 (1.3.0) on probation` |
| `mismatch` | `bundle a72cec65 has not confirmed a boot yet; attempt 2` |
| `corrupt` | `bundle a72cec65 failed to boot 2 times; rolling back to the embedded bundle` |

Every green Windows run has `bundle a72cec65 booted; probation cleared` in the `promoted` launch. Both red ones do not.

## What changed

1. **`WebViewBridge` confirms a boot from the first frame the SDK sends,** not only from the 250 ms poll. A frame over the WebView2 / WKWebView message channel, or a `vidra://` navigation on the fallback transport, proves the bundle's JavaScript parsed, ran and reached native. That is strictly stronger evidence than the poll's `typeof window.__vidra_initialize === 'function'`, and it arrives earlier. The poll stays, for a bundle that boots the SDK and never calls into native, and now takes its first sample immediately instead of after a wait.
2. **`OnNavigated` starts the watcher even if a push throws.** Windows really does throw here: `EvaluateJavaScriptAsync` reports "a valid CoreWebView2 is not present" when the handler is between platform views.
3. **`UpdateClient` re-reads state before its post-install write** instead of writing back the snapshot the check began with. A boot confirmation that landed during the download was being overwritten.
4. **The e2e asserts the boot was confirmed, in the `promoted` phase.** The fault is now reported where it happens.

This is option 2 from the issue, and its stated cost does not apply: **no bridge contract change is needed.**

## What a reviewer should decide

- Whether an inbound bridge frame is an acceptable definition of "booted". It is what the poll was approximating; a bundle that sends a frame has done everything the poll checks for and more.
- Whether the `UpdateClient` re-read belongs in this PR. It is three words and the same class of bug, but no observed failure is attributed to it.

## Evidence

The diagnosis is from CI logs alone; the rate is measured over 25 cycles per branch. Everything below was produced on the fork, `horatiuvlad/vidra-fork`, and the branch here is rebased onto `e83a27b` with CI green on all three legs ([run 31426354886](https://github.com/horatiuvlad/vidra-fork/actions/runs/31426354886)).

<details>
<summary>The three launches, and what each one logged</summary>

Run [31192162593 attempt 1](https://github.com/horatiuvlad/vidra-fork/actions/runs/31192162593), `Smoke (windows-latest)`, on a branch that touches no runtime code.

```
launch: promoted
    [vidra] update: promoting bundle a72cec65 (1.3.0) on probation
    [vidra] update: nothing installable in 1 entries (running 1.3.0)
    marker=ota-bundle-1-3-0 current=1.3.0 pending=null counter=1

launch: mismatch
    [vidra] update: bundle a72cec65 has not confirmed a boot yet; attempt 2
    marker=ota-bundle-1-3-0 current=1.3.0 pending=null counter=1

launch: corrupt
    [vidra] update: bundle a72cec65 failed to boot 2 times; rolling back to the embedded bundle
    [vidra] update: BundleVerificationException: bundle 1.5.0 failed verification
    marker=undefined current=null pending=null counter=1
```

The rollback is logged by `ApplyStartupTransition`, before the feed is read. The 1.5.0 rejection in the same launch comes from the background check afterwards and writes no state. The passing re-run of the same commit rejected 1.5.0 identically and kept serving 1.3.0.

The `promoted` launch had `counter: 1`, so the bundle had already completed a bridge round trip. That round trip is a `window.chrome.webview.postMessage` frame arriving at `HandleNativeInbound`, which is exactly the signal this PR now listens to.

</details>

<details>
<summary>Alternatives ruled out</summary>

| hypothesis | ruled out by |
|---|---|
| Rejecting a bad bundle discards the installed one | The rollback is logged at startup, before the feed is read. `UpdateClient.CheckAsync` returns `State = null` on the rejection path and writes nothing. |
| The install directory was left half-written | `BundleInstaller` hashes the archive before extracting, stages under `.staging-<sha>`, and only renames on success. The proof says `currentBundle: null`: state had no `Current` at all. |
| State was truncated rather than deleted | `UpdateState.Parse` resolves damage to `Empty`, which has no `Blocked` list. The next launch reported `1 already rejected after failing to boot`, so `Blocked` survived and the file parsed fine. |
| The app never started | Every launch wrote a proof, with `counter: 1` and `href: https://vidra.invalid/index.html`. |

</details>

<details>
<summary>Measured, before and after</summary>

`tests/smoke/ota-boot-repeat.mjs`, a probe harness that is not part of this PR, 25 stage-then-promote cycles per run, `<app data>/vidra` wiped between cycles, Windows CI:

| branch | cycles | probation cleared | not cleared |
|---|---|---|---|
| baseline (`main` @ `a38ec4a`) | 25 | 18 | **7 (28%)** |
| with this change | 25 | **25** | 0 |

Runs [31198537335](https://github.com/horatiuvlad/vidra-fork/actions/runs/31198537335) and [31198539183](https://github.com/horatiuvlad/vidra-fork/actions/runs/31198539183). The two probe branches are kept as `archive/probe/ota-boot-confirm` and `archive/probe/ota-boot-confirm-fixed` tags on the fork if the harness is worth re-running.

28% matches the issue's estimate of roughly one run in three. Getting 0 out of 25 by luck at a 28% rate is p = 0.72^25, about 3 in 10,000.

The traces say exactly where the time goes. A baseline cycle that cleared:

```
0ms:   navigated (subscribed=True)
54ms:  pushed __vidra_native
106ms: pushed __vidra_initialize
106ms: starting watcher
359ms: probe 0 asking
364ms: probe 0 answer=true
       bundle a72cec65 booted; probation cleared
```

A baseline cycle that did not, from the same run:

```
0ms:   navigated (subscribed=True)
75ms:  pushed __vidra_native
147ms: pushed __vidra_initialize
147ms: starting watcher
       (no probe line: the process exited before 397ms)
```

The watcher started, and its first sample was scheduled 250 ms later than it needed to be. With this change, all 25 cycles confirmed from `native-frame`, at 68 ms in the first cycle, before the poll would have started at all.

The measured branch carries the first commit here. The second, which starts the watcher even when a push throws, was added after the runs; it can only add confirmations, never remove them.

Unit tests: 107 pass in `Vidra.Updates.Tests`, including the new one, which fails without the `UpdateClient` change. The Windows OTA e2e is green on both probe branches, so the new `probation cleared` assertion does not misfire on a good run.

</details>

## Still open, deliberately

A rolled-back bundle goes on `Blocked` and is never offered again. That is right for a bundle that cannot boot and wrong for one that lost a race twice. This change makes losing much less likely; it does not make the consequence recoverable. Worth a follow-up, not worth widening this PR.
