### PR TITLE
The release workflows can report a release they never made

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -44,7 +44,8 @@ jobs:
     needs: verify
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # Write, only so a successful publish can leave a tag behind.
+      contents: write
       # Required for npm provenance, which signs a verifiable link between the
       # published tarball and the commit + workflow that produced it.
       id-token: write
@@ -60,6 +61,70 @@ jobs:
           cache-dependency-path: |
             src/cli/create-vidra-app/package-lock.json
             src/sdk/vidra-js/package-lock.json
+
+      # npm-publish.sh skips a package that is already on the registry, which is
+      # what lets a "publish both" run work when only one was bumped — and it is
+      # also what makes a re-run at an already-released version skip everything
+      # and report success. Both packages skipping is the case that reads as a
+      # release and is not one, so decide it here, before anything is published.
+      - name: Refuse a run with nothing to publish
+        run: |
+          case "${{ inputs.packages }}" in
+            both) dirs=(src/sdk/vidra-js src/cli/create-vidra-app) ;;
+            sdk)  dirs=(src/sdk/vidra-js) ;;
+            cli)  dirs=(src/cli/create-vidra-app) ;;
+          esac
+          pending=0
+          for dir in "${dirs[@]}"; do
+            spec="$(node -p "const p=require('./$dir/package.json'); p.name + '@' + p.version")"
+            if npm view "$spec" version >/dev/null 2>&1; then
+              echo "  $spec — already on the registry, will be skipped"
+            else
+              echo "  $spec — to publish"
+              pending=$((pending + 1))
+            fi
+          done
+          if [ "$pending" -gt 0 ]; then
+            echo "$pending package(s) to publish"
+            exit 0
+          fi
+          # A dry run that would publish nothing is a useful answer, not a
+          # failure; only the run that claims to be a release has to refuse.
+          if [ "${{ inputs.push }}" != "true" ]; then
+            echo "::warning::nothing to publish: every selected package is already on npm at this version"
+            exit 0
+          fi
+          echo "::error::every selected package is already on npm at this version — run the Bump version workflow before releasing again"
+          exit 1
+
+      # The scaffolded host csproj pins two packages at this exact version from
+      # nuget.org — `{{vidraVersion}}` is the one token that has no monorepo
+      # fallback, so a published CLI whose NuGet half is not out yet scaffolds
+      # apps that cannot restore. That is why the two release workflows are not
+      # interchangeable in order: NuGet first, npm second. 0.4.0 got away with a
+      # two-minute window; it is not a rule, it was luck.
+      #
+      # Both ids are checked, not just one. `dotnet nuget push` pushes nine
+      # packages in one glob and can fail part way, so "one of them is up" is not
+      # the same claim as "the set the template needs is up".
+      - name: The NuGet half has to be out first
+        if: ${{ inputs.push && (inputs.packages == 'both' || inputs.packages == 'cli') }}
+        run: |
+          version="$(node -p "require('./version.json').version")"
+          missing=0
+          for id in vidra.hosting.maui vidra.updates.native; do
+            if curl -sf "https://api.nuget.org/v3-flatcontainer/$id/index.json" \
+                 | jq -e --arg v "$version" '.versions | index($v)' >/dev/null 2>&1; then
+              echo "  $id $version is on nuget.org"
+            else
+              echo "  $id $version is NOT on nuget.org"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing package(s) the scaffolded template pins are not on nuget.org at $version — run Release NuGet first, or every app scaffolded by this CLI will fail to restore"
+            exit 1
+          fi
 
       - name: Publish @vidra-dev/sdk
         if: ${{ inputs.packages == 'both' || inputs.packages == 'sdk' }}
@@ -81,6 +146,13 @@ jobs:
           PUSH: ${{ inputs.push }}
           PROVENANCE: ${{ inputs.provenance }}
         run: bash "$GITHUB_WORKSPACE/tests/ci/npm-publish.sh"
+
+      # See tests/ci/tag-release.sh: nothing has ever tagged a release, so which
+      # commit a published version came from is only recoverable from a run's
+      # timestamp. Both release workflows tag, and neither minds finding it done.
+      - name: Tag the published version
+        if: ${{ inputs.push }}
+        run: bash tests/ci/tag-release.sh
 
       - name: Summary
         if: always()

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -54,6 +54,13 @@ jobs:
       # See ci.yml: the macos runner image tops out below the Xcode the newest
       # maccatalyst manifest wants, so pin the newest available and skip the
       # manifest update during workload install.
+      #
+      # NOTE: this pin and the one below no longer match ci.yml, which dropped
+      # both when the image moved to Xcode 26.6 and the Catalyst pack started
+      # requiring the 26.5 SDK. So this job packs on a toolchain the suite that
+      # gates it does not use. Deliberately left alone here: it only takes effect
+      # on a real pack run, which no PR exercises, so it belongs with the release
+      # that can prove it rather than with a batch of guards that CI can.
       - name: Select newest available Xcode (macOS)
         if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
@@ -79,6 +86,9 @@ jobs:
     name: Merge${{ inputs.push && ' + push' || ' (dry run)' }}
     needs: pack
     runs-on: ubuntu-latest
+    permissions:
+      # Write, only so a successful publish can leave a tag behind.
+      contents: write
     steps:
       - uses: actions/checkout@v7
 
@@ -119,6 +129,39 @@ jobs:
           path: merged/*.nupkg
           if-no-files-found: error
 
+      # `--skip-duplicate` below is what makes a retry work after a push fails
+      # part-way through nine packages, and it should stay. What it cannot tell
+      # apart is the run where *every* package is already published: that one
+      # skips all nine, pushes nothing, and reports success — which reads as a
+      # release. nuget.org is the ground truth for what is already out, so ask
+      # it before pushing, while "nothing to do" can still be told apart from
+      # "done".
+      - name: Refuse a push with nothing to publish
+        if: ${{ inputs.push }}
+        run: |
+          pending=0
+          for pkg in merged/*.nupkg; do
+            base="$(basename "$pkg" .nupkg)"
+            if [[ ! "$base" =~ ^(.+)\.([0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?)$ ]]; then
+              echo "::error::cannot read an id and version out of $base"; exit 1
+            fi
+            id="${BASH_REMATCH[1]}"
+            version="${BASH_REMATCH[2]}"
+            lower="$(echo "$id" | tr '[:upper:]' '[:lower:]')"
+            if curl -sf "https://api.nuget.org/v3-flatcontainer/$lower/index.json" \
+                 | jq -e --arg v "$version" '.versions | index($v)' >/dev/null 2>&1; then
+              echo "  $id $version — already on nuget.org, will be skipped"
+            else
+              echo "  $id $version — to publish"
+              pending=$((pending + 1))
+            fi
+          done
+          if [ "$pending" -eq 0 ]; then
+            echo "::error::every packed version is already on nuget.org — run the Bump version workflow before releasing again"
+            exit 1
+          fi
+          echo "$pending package(s) to publish"
+
       - name: Push to nuget.org
         if: ${{ inputs.push }}
         run: |
@@ -126,3 +169,11 @@ jobs:
             --api-key "${{ secrets.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate
+
+      # Nothing has ever tagged a release, so the only record of which commit a
+      # published version was built from is a workflow run's timestamp. Both
+      # release workflows create the tag and neither minds finding it already
+      # there — the second one to publish a given version is not a failure.
+      - name: Tag the published version
+        if: ${{ inputs.push }}
+        run: bash tests/ci/tag-release.sh

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -72,11 +72,38 @@ jobs:
           echo "next=$next" >> "$GITHUB_OUTPUT"
           echo "$current -> $next"
 
+      # "Released" means the registries, not this repository. The tag check came
+      # first and could never have fired: no release created a tag until
+      # tests/ci/tag-release.sh did, so 0.4.0 went out to npm and nuget.org with
+      # no v0.4.0 to find. The tag check stays — it is the cheap one, and it now
+      # has tags to catch — but the registries are asked as well, because they
+      # are what refuses the publish this bump is supposed to be preparing.
+      #
+      # Each registry is reached first and asked second. A check that passes
+      # because the network was down is the same useless check as the tag lookup
+      # that could never fire, so "could not ask" fails here rather than waving
+      # the bump through.
       - name: Refuse to reuse a released version
         run: |
-          if git rev-parse "v${{ steps.next.outputs.next }}" >/dev/null 2>&1; then
-            echo "::error::tag v${{ steps.next.outputs.next }} already exists"; exit 1
+          next="${{ steps.next.outputs.next }}"
+          if git rev-parse "v$next" >/dev/null 2>&1; then
+            echo "::error::tag v$next already exists"; exit 1
           fi
+
+          if ! npm view create-vidra-app version >/dev/null 2>&1; then
+            echo "::error::could not reach npm to check whether $next is taken"; exit 1
+          fi
+          if npm view "create-vidra-app@$next" version >/dev/null 2>&1; then
+            echo "::error::create-vidra-app@$next is already on npm"; exit 1
+          fi
+
+          if ! nuget="$(curl -sSf "https://api.nuget.org/v3-flatcontainer/vidra.bridge/index.json")"; then
+            echo "::error::could not reach nuget.org to check whether $next is taken"; exit 1
+          fi
+          if printf '%s' "$nuget" | jq -e --arg v "$next" '.versions | index($v)' >/dev/null; then
+            echo "::error::Vidra.Bridge $next is already on nuget.org"; exit 1
+          fi
+          echo "$next is unreleased on both registries"
 
       - name: Apply the bump
         run: |

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -22,6 +22,28 @@ const SOURCE = path.join(ROOT, "version.json");
 
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
 
+/** Both places an npm lockfile names its own package's version. */
+const writeLockVersion = (source, version) => {
+  const lock = JSON.parse(source);
+  lock.version = version;
+  if (lock.packages?.[""]) lock.packages[""].version = version;
+  return `${JSON.stringify(lock, null, 2)}\n`;
+};
+
+/**
+ * Read both, and report the disagreement rather than the root value when they
+ * differ — otherwise `check` passes on a lockfile that names two versions of
+ * itself, which is the drift this is here to catch.
+ */
+const readLockVersion = (source) => {
+  const lock = JSON.parse(source);
+  const inner = lock.packages?.[""]?.version;
+  if (inner !== undefined && inner !== lock.version) {
+    return `${lock.version} at the root, ${inner} under packages[""]`;
+  }
+  return lock.version;
+};
+
 /** Files that carry a copy of the version, and how to read/write it. */
 const derived = [
   {
@@ -41,6 +63,22 @@ const derived = [
     file: "src/cli/create-vidra-app/src/theme.ts",
     read: (s) => s.match(/CLI_VERSION = "([^"]+)"/)?.[1],
     write: (s, v) => s.replace(/(CLI_VERSION = ")[^"]+(")/, `$1${v}$2`),
+  },
+  {
+    // A lockfile records the version of the package it locks, in two places.
+    // `npm ci` does not mind if they disagree with package.json and the
+    // published tarball takes its version from package.json either way — so
+    // this drifts silently, which is the one thing version.json exists to stop.
+    // Rewritten by round-trip because npm's own formatting is exactly
+    // JSON.stringify(…, 2) plus a newline.
+    file: "src/cli/create-vidra-app/package-lock.json",
+    read: readLockVersion,
+    write: writeLockVersion,
+  },
+  {
+    file: "src/sdk/vidra-js/package-lock.json",
+    read: readLockVersion,
+    write: writeLockVersion,
   },
   {
     // Every packable csproj resolves <Version> through this property, so the

--- a/src/cli/create-vidra-app/package-lock.json
+++ b/src/cli/create-vidra-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-vidra-app",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "create-vidra-app",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",

--- a/tests/ci/tag-release.sh
+++ b/tests/ci/tag-release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Tag the commit a release was published from, as v<version.json>.
+#
+# Called by both release workflows after a successful publish. Either one can
+# run first, or alone, or both at once, so finding the tag already on this
+# commit is the ordinary case and not an error. Finding it on a *different*
+# commit is: two publishes of one version from two trees is exactly the thing
+# the tag exists to make visible.
+set -euo pipefail
+
+VERSION="$(node -p "require('./version.json').version")"
+TAG="v$VERSION"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+# `git ls-remote` reports an annotated tag by its *tag object* sha; the commit it
+# points at is the peeled `^{}` entry, and asking for `refs/tags/<tag>` by pattern
+# filters that entry out. Read the peeled one, or the comparison below can never
+# match and the second workflow to publish fails on a tag it should accept.
+remote_commit() {
+  git ls-remote --tags origin |
+    awk -v t="refs/tags/$TAG" '$2 == t "^{}" { peeled = $1 } $2 == t { plain = $1 } END { print (peeled != "" ? peeled : plain) }'
+}
+
+existing="$(remote_commit)"
+
+if [ -z "$existing" ]; then
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  git tag -a "$TAG" -m "$TAG"
+  if git push origin "refs/tags/$TAG"; then
+    echo "==> tagged $TAG at $HEAD_SHA"
+    exit 0
+  fi
+  echo "==> lost the tag push race, re-reading"
+  existing="$(remote_commit)"
+fi
+
+if [ "$existing" = "$HEAD_SHA" ]; then
+  echo "==> $TAG already points at this commit"
+  exit 0
+fi
+
+echo "::error::$TAG already exists on origin at $existing, but this release is $HEAD_SHA"
+exit 1


### PR DESCRIPTION
Re-run **Release npm** or **Release NuGet** today, with 0.4.0 already on both registries, and the workflow goes green having pushed nothing. Nothing in the repo tells you the difference between that and a real release.

That is the main fix. Three more, all in the same path, plus the version derivation that has to be right before the next bump.

### What was wrong

**1. A run that publishes nothing reports success.** `--skip-duplicate` and `npm-publish.sh`'s registry check exist so a retry works after a push dies half way through. Neither can tell "4 of 9 still to push" from "all 9 already out".

**2. The bump workflow's safety check has never fired.** "Refuse to reuse a released version" looks for a `v<next>` git tag. No workflow has ever made one and the repo has zero tags, so it has always passed. An `explicit` bump back to 0.4.0 would have gone straight through.

**3. No release leaves a tag.** Which commit 0.4.0 shipped from is only recoverable by matching workflow run timestamps against registry publish times.

**4. npm can publish before NuGet.** The CLI stamps `Vidra.Hosting.Maui` and `Vidra.Updates.Native` into every scaffolded app at an exact version, and that token has no local fallback, so a CLI published ahead of its NuGet half scaffolds apps that cannot `dotnet restore`. This already happened: 0.4.0 went to npm at 16:31:40 UTC and to nuget.org at 16:33:58.

**5. The lockfiles were not derived.** `version.mjs set` moved five files and left two behind. Both `package-lock.json` files name their own version twice, at the root and under `packages[""]`, and nothing rewrote or checked them. The CLI's already said 0.3.1 while its `package.json` said 0.4.0.

### What changes

* Both release workflows ask the registry before publishing and fail when there is nothing left to do. A partial retry still goes ahead, and a dry run still reports rather than failing.
* The bump workflow asks npm and nuget.org as well as git, and fails on "could not reach the registry" rather than treating it as "that version is free".
* New `tests/ci/tag-release.sh`, run by both release workflows after a successful publish. Idempotent, and it treats losing the tag push race to the other workflow as the ordinary outcome it is.
* `version.mjs` derives both lockfiles, by JSON round trip, and `check` reads both copies so a lockfile whose halves disagree cannot pass.

Both publishing jobs now ask for `contents: write` so the tag can be pushed. Nothing else in their permissions changes.

### One thing deliberately not included

`release-nuget.yml` still pins Xcode 26.3 and `--skip-manifest-update`. `ci.yml` dropped both when the runner image moved to Xcode 26.6 and the Mac Catalyst pack started needing the 26.5 SDK, so this job packs on a toolchain the suite that gates it does not use. That divergence is real and the file now carries a note saying so, but it only takes effect on a pack run that no PR exercises. It belongs with the release that can actually prove it, not with a batch of guards that CI can.

<details>
<summary>How the 0.4.0 timeline was established</summary>

The repo has no tags and no releases, so both release workflows had to be correlated by hand. Both ran 2026-08-02 16:12 UTC from `main` at `6b65a8c`. `create-vidra-app@0.4.0` and `@vidra-dev/sdk@0.4.0` published at 16:31:40, every `Vidra.*` package at 16:33:58. Published 0.4.0 therefore contains #6, #7 and #9, and `Vidra.Updates` / `Vidra.Updates.Native` have no other version.

The lockfile round trip was checked byte for byte on both files, and again after a real `npm install` under npm 10.9.8 and npm 11. `tag-release.sh` was exercised against a real remote for all three of its cases: fresh tag, tag already on this commit, tag on a different commit.
</details>

