### PR TITLE
Let a failing counter explain itself

### DIFF
--- a/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/MainPage.cs
+++ b/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/MainPage.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Vidra.Hosting;
 
 namespace {{projectName}};
@@ -23,11 +24,16 @@ public class MainPage : VidraPage
         try
         {
             var count = await Bridge.Js().Counter.IncrementAsync();
-            System.Diagnostics.Debug.WriteLine($"[MainPage] Counter is now {count}");
+            Trace.TraceInformation($"[MainPage] Counter is now {count}");
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[MainPage] Counter increment failed: {ex.Message}");
+            // Trace, not Debug: Debug.WriteLine compiles out of a Release build,
+            // which is exactly the build where someone is looking at a counter
+            // stuck at zero and has nothing to report. The whole exception, not
+            // ex.Message, because the bridge's answer to "why" is the error code
+            // on it (JS_HANDLER_NOT_FOUND, JS_HANDLER_ERROR, JS_RESPONSE_INVALID).
+            Trace.TraceError($"[MainPage] Counter increment failed: {ex}");
         }
     }
 }

--- a/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/MainPage.cs
+++ b/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/MainPage.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Vidra.Hosting;
 
 namespace {{projectName}};
@@ -24,16 +23,22 @@ public class MainPage : VidraPage
         try
         {
             var count = await Bridge.Js().Counter.IncrementAsync();
-            Trace.TraceInformation($"[MainPage] Counter is now {count}");
+            Console.WriteLine($"[MainPage] Counter is now {count}");
         }
         catch (Exception ex)
         {
-            // Trace, not Debug: Debug.WriteLine compiles out of a Release build,
-            // which is exactly the build where someone is looking at a counter
-            // stuck at zero and has nothing to report. The whole exception, not
-            // ex.Message, because the bridge's answer to "why" is the error code
-            // on it (JS_HANDLER_NOT_FOUND, JS_HANDLER_ERROR, JS_RESPONSE_INVALID).
-            Trace.TraceError($"[MainPage] Counter increment failed: {ex}");
+            // Console, which is what Vidra.Hosting itself logs through, and the
+            // only one of the three that a Release build actually emits.
+            // Debug.WriteLine is compiled out of Release entirely, and Release is
+            // exactly the build where someone is looking at a counter stuck at
+            // zero. Trace.TraceError survives the compile but goes to
+            // DefaultTraceListener, which writes nothing unless a debugger is
+            // attached, and this template registers no listener.
+            //
+            // The whole exception, not ex.Message: the bridge's answer to "why"
+            // is the error code on it, and JS_HANDLER_NOT_FOUND, JS_HANDLER_ERROR
+            // and JS_RESPONSE_INVALID are three different problems.
+            Console.Error.WriteLine($"[MainPage] Counter increment failed: {ex}");
         }
     }
 }


### PR DESCRIPTION
Part of #14, item 3. This does not fix the counter. It makes a failing counter able to explain itself, which is worth having whatever the root cause turns out to be.

`OnTickAsync` in the scaffolded template catches its exception and writes it to `Debug.WriteLine`. Two problems with that:

**`Debug.WriteLine` is compiled out of a Release build.** A stuck counter is something you look at in a Release build, so the one line that would explain it is discarded exactly when it is needed.

**It logged `ex.Message` only.** The bridge's answer to "why" is the error code on the exception, and `JS_HANDLER_NOT_FOUND`, `JS_HANDLER_ERROR` and `JS_RESPONSE_INVALID` are three very different problems. The whole exception goes to the log now.

### Why Console and not Trace

`Trace.TraceError` is the obvious swap, since `TRACE` is defined in Release while `DEBUG` is not, and it is the wrong one. Trace goes to `DefaultTraceListener`, which writes through `Debugger.Log` and emits nothing at all unless a debugger is attached. This template registers no listener, and `MauiProgram` only calls `builder.Logging.AddDebug()` under `#if DEBUG`, so a Release build has no provider either. Measured on a Release build: the call runs and no output reaches stdout, stderr or anywhere else.

`Console` is what `Vidra.Hosting` already logs through (the `[vidra] ...` lines in `WebAssetRoot`, `VidraUpdateService` and `VidraPage`) and it is what the CI smoke legs capture, so a scaffolded app now reports a failure the same way the framework under it does.

### Scope

Template only, so it changes what new apps are created with. One file, and nothing but logging.

<details>
<summary>What ruling out item 1 of the same issue turned up, since it touches the same template</summary>

Item 1 (the app does not scroll) blamed the template's CSS. Measured in Chromium, it is not the cause.

The exact rules the issue names (`html, body { height: 100% }` against `body { min-height: 100dvh; display: flex }`, plus the fixed full viewport `body::before`) with a document taller than the viewport: `scrollHeight` 8032 against `clientHeight` 577, and a real wheel event through CDP moves `scrollTop` to 400. The scaffolded app's own built `ui/` behaves the same: 846 against 577, wheel scrolls to the 269 maximum. `elementFromPoint` at the viewport centre returns the content, not `body::before`, so `pointer-events: none` is doing its job.

That result is about layout, and layout is the part Chromium and WebView2 share, so it rules the CSS out. It says nothing about how the wheel gets from WinUI into the web content, or about what viewport height the host hands the WebView2 control, and those are the remaining suspects. `VidraPage` sets the `WebView` as `Content` with `Fill` on both axes and no `ScrollView` around it, which is the correct arrangement.

Item 2 is untested here: it needs a Windows box and `signtool verify` against a build whose certificate configuration is known.
</details>

