### PR TITLE
One restore graph for Catalyst, so an incremental publish cannot read a narrowed assets file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,6 +521,31 @@ jobs:
           [ "$short" = "1.2.3" ] || { echo "::error::expected 1.2.3 from package.json, got $short"; exit 1; }
           [ "$build" = "10203" ] || { echo "::error::expected build 10203, got $build"; exit 1; }
 
+      # The bundle that ships is the one at the TFM root: `stepDotnetPublish`
+      # returns `bin/Release/<tfm>` and `macosTarget.findBundle` reads exactly
+      # that directory, non-recursively, so that is what gets signed, DMG'd and
+      # packed. The Catalyst SDK lipos the per-RID builds into it, which is why
+      # it is universal — and it has to stay that way, because a single RID
+      # pinned anywhere upstream of here would silently ship half an app to
+      # everyone on the other architecture.
+      - name: The packaged app is universal (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        working-directory: ${{ runner.temp }}/vidra-smoke
+        run: |
+          root=src/VidraSmoke.Host/bin/Release/net10.0-maccatalyst
+          app="$(find "$root" -maxdepth 1 -name '*.app' -type d -print -quit)"
+          [ -n "$app" ] || { echo "::error::no .app at $root, which is where the CLI looks"; exit 1; }
+          bin="$app/Contents/MacOS/$(ls "$app/Contents/MacOS" | head -1)"
+          archs="$(lipo -archs "$bin")"
+          echo "$app -> $archs"
+          for want in x86_64 arm64; do
+            case " $archs " in
+              *" $want "*) ;;
+              *) echo "::error::$bin is missing the $want slice (got: $archs)"; exit 1 ;;
+            esac
+          done
+
       - name: The app version reached the artifact name
         shell: bash
         working-directory: ${{ runner.temp }}/vidra-smoke

--- a/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/{{projectName}}.Host.csproj
+++ b/src/cli/create-vidra-app/templates/react-vite/src/{{projectName}}.Host/{{projectName}}.Host.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Pinned, not inferred: a Release Catalyst publish is universal
+         (maccatalyst-x64 + maccatalyst-arm64) while a Debug build takes
+         the host RID alone, and both share one obj/. Whichever restored
+         last owns project.assets.json, so a publish that no-ops its
+         restore can read an assets file with no x64 target and fail with
+         NETSDK1047. Naming the set here makes every restore write both. -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">net10.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.19041.0</TargetFrameworks>
     <ValidateXcodeVersion>false</ValidateXcodeVersion>

--- a/src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj
+++ b/src/host/Vidra.Host.Maui/Vidra.Host.Maui.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <!-- Pinned, not inferred: a Release Catalyst publish is universal
+         (maccatalyst-x64 + maccatalyst-arm64) while a Debug build takes
+         the host RID alone, and both share one obj/. Whichever restored
+         last owns project.assets.json, so a publish that no-ops its
+         restore can read an assets file with no x64 target and fail with
+         NETSDK1047. Naming the set here makes every restore write both. -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">maccatalyst-x64;maccatalyst-arm64</RuntimeIdentifiers>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('osx'))">net10.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">net10.0-windows10.0.19041.0</TargetFrameworks>
     <ValidateXcodeVersion>false</ValidateXcodeVersion>


### PR DESCRIPTION
The macOS smoke leg fails intermittently at "Rebuilding a published version skips the pack and leaves the feed alone" with

```
error NETSDK1047: Assets file '.../obj/project.assets.json' doesn't have a target
for 'net10.0-maccatalyst/maccatalyst-x64'
```

after four identical publishes in the same job have already succeeded. Seen on [run 31426356218](https://github.com/horatiuvlad/vidra-fork/actions/runs/31426356218); the rerun was green, which is the whole problem with it.

## Why

One `obj/` serves two different RID sets.

- A **Debug** or RID-less build takes the host RID alone. Restore writes `net10.0-maccatalyst` and `net10.0-maccatalyst/maccatalyst-arm64`.
- A **Release publish** is per-RID: it builds `maccatalyst-x64` *and* `maccatalyst-arm64`. Restore writes both targets.

`project.assets.json` belongs to whichever restored last, so it flips between one target and two as a job moves between Debug builds, dev-loop builds and publishes. That alone is survivable, because the next publish normally re-restores and repairs it. It stops being survivable when the publish skips its restore: the no-op check reads `project.nuget.cache`, not the assets file, so a publish can be told it has nothing to do and then read an assets file with no x64 target. It fails in under two seconds, which is how the failing step ran faster than the passing one.

Naming the RID set in the project makes every restore write both targets, so the narrow state cannot be built in the first place.

## Measured

A probe on the dogfood host, dumping the assets targets after each step, then forcing the skip by restoring the universal publish's `project.nuget.cache` over the narrowed one:

| after | without `RuntimeIdentifiers` | with it |
|---|---|---|
| Debug build | arm64 only | x64 + arm64 |
| Release publish | x64 + arm64 | x64 + arm64 |
| Debug build again | arm64 only | x64 + arm64 |
| publish with the kept restore cache | **NETSDK1047, exit 1** | **exit 0** |

Runs [31431674769](https://github.com/horatiuvlad/vidra-fork/actions/runs/31431674769) (before) and [31431674984](https://github.com/horatiuvlad/vidra-fork/actions/runs/31431674984) (with this change). Same error, same targets file, same line as CI hit.

What is still unexplained is what makes the restore no-op *naturally* in the smoke job, where nothing copies a cache file around. This change removes the assets-file half of the pair, which the failure needs, so it holds whatever the trigger turns out to be.

## The CI step that comes with it

`vidra build` signs and packages the `.app` at the TFM root: `stepDotnetPublish` returns `bin/Release/<tfm>` and `macosTarget.findBundle` reads exactly that directory, non-recursively. The Catalyst SDK lipos the per-RID builds into that bundle, so it is universal, and the new step asserts it stays universal rather than trusting it. On this branch it reports:

```
src/VidraSmoke.Host/bin/Release/net10.0-maccatalyst/Vidra Smoke.app -> x86_64 arm64
```

Without it, a single RID pinned anywhere upstream of the publish would ship half an app to everyone on the other architecture, and nothing in the suite would notice.

Nothing else changes: the RID set named here is the one a Release publish already used.

